### PR TITLE
feat: add possibility to customize pull & push requests & syncTerms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 `2021-09-02`
 
 - 🌟 Added possibility to pass custom parameters to pull or push API requests
+- 🌟 Added syncTerms option support
 
 ## 1.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.15.0
+
+`2021-09-02`
+
+- 🌟 Added possibility to pass custom parameters to pull or push API requests
+
 ## 1.14.0
 
 `2021-03-11`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Create a **poeditor-config.json** in the root directory, and config information 
   "projectId": 0,                     // project id
   "fileType": "",                     // fileType to upload or download, supports files format (po, pot, mo, xls, csv, resw, resx, android_strings, apple_strings, xliff, properties, key_value_json, json, xmb, xtb)
   "targetDir": "",                    // directory where translated files live
+  "syncTerms": true,                  // (optional) set it to true if you want to sync your terms (terms that are not found in the uploaded file will be deleted from project and the new ones added)
+  "sourceLang": "en-US",              // (optional, required when syncTerms set to true) language to sync the terms from
   "pullParams": {},                   // (optional) allows to pass any parameters available on the POEditor's export endpoint, full list here: https://poeditor.com/docs/api#projects_export
   "pushParams": {}                    // (optional) allows to pass any parameters available on the POEditor's upload endpoint, full list here: https://poeditor.com/docs/api#projects_upload
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Create a **poeditor-config.json** in the root directory, and config information 
   "apiToken": "",                     // POEditor api token
   "projectId": 0,                     // project id
   "fileType": "",                     // fileType to upload or download, supports files format (po, pot, mo, xls, csv, resw, resx, android_strings, apple_strings, xliff, properties, key_value_json, json, xmb, xtb)
-  "targetDir": ""                     // directory where translated files live
+  "targetDir": "",                    // directory where translated files live
+  "pullParams": {},                   // (optional) allows to pass any parameters available on the POEditor's export endpoint, full list here: https://poeditor.com/docs/api#projects_export
+  "pushParams": {}                    // (optional) allows to pass any parameters available on the POEditor's upload endpoint, full list here: https://poeditor.com/docs/api#projects_upload
 }
 ```
 

--- a/packages/commands/pull.js
+++ b/packages/commands/pull.js
@@ -64,6 +64,7 @@ async function getTermFiles(config) {
       id: config.projectId,
       language: lang.code,
       type: tempFileType,
+      ...(config.pullParams || {})
     };
 
     try {

--- a/packages/commands/push.js
+++ b/packages/commands/push.js
@@ -120,6 +120,10 @@ async function putTermFile(config) {
   formData.append("updating", "terms_translations");
   formData.append("file", fs.createReadStream(config.file));
   formData.append("overwrite", "1");
+  if (config.pushParams) {
+    Object.keys(config.pushParams)
+      .forEach(paramName => formData.set(paramName, config.pushParams[paramName]))
+  }
 
   const res = await api.post("/projects/upload", formData, {
     headers: {

--- a/packages/commands/push.js
+++ b/packages/commands/push.js
@@ -120,6 +120,11 @@ async function putTermFile(config) {
   formData.append("updating", "terms_translations");
   formData.append("file", fs.createReadStream(config.file));
   formData.append("overwrite", "1");
+  
+  if (config.syncTerms && config.sourceLang && config.language === config.sourceLang) {
+    formData.append('sync_terms', '1');
+  }
+
   if (config.pushParams) {
     Object.keys(config.pushParams)
       .forEach(paramName => formData.set(paramName, config.pushParams[paramName]))


### PR DESCRIPTION
Hi!

In this PR I've added possibility to customize push (upload) & pull (export) requests when using this cli.

In my use case I needed to use `sync_terms` & `tags` options of the upload endpoint (to remove terms which doesn't exist in my source file).

WDYT?